### PR TITLE
Fix CI: use macOS 15 runner with Xcode 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,14 +9,18 @@ on:
 jobs:
   test:
     name: Test
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
 
-      - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_15.4.app || sudo xcode-select -s /Applications/Xcode.app
+      - name: Select latest Xcode
+        run: |
+          XCODE_PATH=$(ls -d /Applications/Xcode_16*.app 2>/dev/null | sort -V | tail -1)
+          if [ -z "$XCODE_PATH" ]; then XCODE_PATH=/Applications/Xcode.app; fi
+          sudo xcode-select -s "$XCODE_PATH"
+          xcodebuild -version
 
       - name: Install XcodeGen
         run: brew install xcodegen
@@ -40,7 +44,7 @@ jobs:
 
   build:
     name: Build
-    runs-on: macos-14
+    runs-on: macos-15
     needs: test
     if: github.event_name == 'pull_request'
     steps:
@@ -48,8 +52,12 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_15.4.app || sudo xcode-select -s /Applications/Xcode.app
+      - name: Select latest Xcode
+        run: |
+          XCODE_PATH=$(ls -d /Applications/Xcode_16*.app 2>/dev/null | sort -V | tail -1)
+          if [ -z "$XCODE_PATH" ]; then XCODE_PATH=/Applications/Xcode.app; fi
+          sudo xcode-select -s "$XCODE_PATH"
+          xcodebuild -version
 
       - name: Install XcodeGen
         run: brew install xcodegen
@@ -64,15 +72,13 @@ jobs:
         run: xcodegen generate
 
       - name: Build Release
-        env:
-          BUILD_DIR: build/Release
         run: |
           xcodebuild \
             -project WhisperType.xcodeproj \
             -scheme WhisperType \
             -configuration Release \
             build \
-            CONFIGURATION_BUILD_DIR="$GITHUB_WORKSPACE/$BUILD_DIR"
+            CONFIGURATION_BUILD_DIR="$GITHUB_WORKSPACE/build/Release"
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   build-and-release:
     name: Build & Create DMG
-    runs-on: macos-14
+    runs-on: macos-15
     env:
       RELEASE_TAG: ${{ github.event.release.tag_name }}
     steps:
@@ -18,8 +18,12 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_15.4.app || sudo xcode-select -s /Applications/Xcode.app
+      - name: Select latest Xcode
+        run: |
+          XCODE_PATH=$(ls -d /Applications/Xcode_16*.app 2>/dev/null | sort -V | tail -1)
+          if [ -z "$XCODE_PATH" ]; then XCODE_PATH=/Applications/Xcode.app; fi
+          sudo xcode-select -s "$XCODE_PATH"
+          xcodebuild -version
 
       - name: Install tools
         run: brew install xcodegen create-dmg


### PR DESCRIPTION
## Summary
- Switch CI/CD runners from `macos-14` to `macos-15` (has Xcode 16+)
- Auto-select latest Xcode 16 version on runner
- Fixes project format 77 incompatibility with Xcode 15.4

## Test plan
- [ ] CI test job passes on this PR
- [ ] CI build job passes on this PR