### PR TITLE
feat: i18n support (EN/DE), English translation, Homebrew auto-update

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -1,0 +1,62 @@
+name: Update Homebrew Cask
+
+on:
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
+
+jobs:
+  update-cask:
+    name: Update Homebrew Tap
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Get release info
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          RELEASE=$(gh api "repos/${REPO}/releases/latest")
+          TAG=$(echo "$RELEASE" | jq -r '.tag_name')
+          VERSION="${TAG#v}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Download SHA256
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          DMG_NAME="WhisperType-${TAG}-arm64.dmg"
+          gh release download "$TAG" --repo "$REPO" --pattern "${DMG_NAME}.sha256"
+          SHA256=$(awk '{print $1}' "${DMG_NAME}.sha256")
+          echo "SHA256=$SHA256" >> "$GITHUB_ENV"
+
+      - name: Checkout homebrew-tap
+        uses: actions/checkout@v4
+        with:
+          repository: marc1107/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-tap
+
+      - name: Update cask formula
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          cd homebrew-tap
+          sed -i "s/version \".*\"/version \"${VERSION}\"/" Casks/whisper-type.rb
+          sed -i "s/sha256 \".*\"/sha256 \"${SHA256}\"/" Casks/whisper-type.rb
+
+      - name: Commit and push
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          cd homebrew-tap
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Casks/whisper-type.rb
+          git diff --cached --quiet && echo "No changes" && exit 0
+          git commit -m "Update whisper-type to v${VERSION}"
+          git push

--- a/README.de.md
+++ b/README.de.md
@@ -1,0 +1,93 @@
+# WhisperType
+
+Lokale Sprache-zu-Text Diktierfunktion für macOS – komplett offline, powered by whisper.cpp.
+
+## Features
+
+- **100% Lokal** – Keine Daten verlassen deinen Mac. Kein Internet nötig nach dem Modell-Download.
+- **Deutsch & Englisch** – Automatische Spracherkennung, Mischsprachen-Support (z.B. deutsche Sätze mit englischen Fachbegriffen)
+- **Globaler Hotkey** – Funktioniert in jeder App. Einstellbare Tastenkombination.
+- **Füllwort-Filter** – Entfernt automatisch "ähm", "also", "uhm" etc.
+- **Native macOS App** – Menübar-App, kein Dock-Icon, minimaler Ressourcenverbrauch
+
+## Systemanforderungen
+
+- macOS 14 (Sonoma) oder neuer
+- Apple Silicon (M1/M2/M3) empfohlen – Intel wird unterstützt aber langsamer
+- Mindestens 8 GB RAM (16 GB empfohlen für large-v3-turbo Modell)
+- ~3 GB freier Speicher für das Whisper-Modell
+
+## Installation
+
+### DMG Download (empfohlen)
+
+1. Lade die neueste Version von der [Releases-Seite](../../releases/latest) herunter
+2. Öffne die `.dmg` Datei
+3. Ziehe WhisperType in den Programme-Ordner
+4. Starte WhisperType — beim ersten Start wird das Whisper-Modell heruntergeladen (~1.5 GB)
+
+### Homebrew
+
+```bash
+brew tap marc1107/tap
+brew install --cask whisper-type
+```
+
+### Aus Source bauen
+
+1. Xcode 15+ und Homebrew installieren
+2. Repository klonen:
+   ```bash
+   git clone --recursive https://github.com/marc1107/whisper-type.git
+   cd whisper-type
+   ```
+3. Bauen:
+   ```bash
+   brew install cmake xcodegen
+   make build
+   ```
+4. App starten:
+   ```bash
+   open build/Release/WhisperType.app
+   ```
+
+### Berechtigungen einrichten
+
+Nach dem ersten Start muss WhisperType in den Systemeinstellungen freigegeben werden:
+1. **Mikrofon:** Wird automatisch angefragt
+2. **Bedienungshilfen:** Systemeinstellungen → Datenschutz & Sicherheit → Bedienungshilfen → WhisperType aktivieren
+
+## Benutzung
+
+1. WhisperType startet als Mikrofon-Icon in der Menüleiste
+2. Klicke in ein beliebiges Textfeld (Browser, Editor, Chat, IDE...)
+3. Drücke den Hotkey (Standard: Fn+Control)
+4. Sprich deinen Text
+5. Lasse los (Push-to-Talk) oder drücke erneut (Toggle-Modus)
+6. Der transkribierte Text wird automatisch eingefügt
+
+## Einstellungen
+
+Über das Menübar-Icon → Einstellungen:
+- Hotkey ändern
+- Push-to-Talk oder Toggle-Modus
+- Whisper-Modell wechseln
+- Sprache festlegen oder automatisch erkennen lassen
+- Füllwort-Filter konfigurieren
+- App-Sprache ändern (Englisch/Deutsch)
+
+## Unterstützte Whisper-Modelle
+
+| Modell | Größe | RAM-Bedarf | Geschwindigkeit | Qualität |
+|--------|-------|------------|-----------------|----------|
+| tiny | 75 MB | ~1 GB | Sehr schnell | Basis |
+| base | 142 MB | ~1 GB | Schnell | Gut |
+| small | 466 MB | ~2 GB | Mittel | Sehr gut |
+| medium | 1.5 GB | ~5 GB | Langsamer | Exzellent |
+| large-v3-turbo | 1.5 GB | ~5 GB | Mittel | Exzellent |
+
+**Empfehlung für M1 16GB:** `large-v3-turbo` – beste Balance aus Qualität und Geschwindigkeit.
+
+## Lizenz
+
+MIT License

--- a/README.md
+++ b/README.md
@@ -1,92 +1,95 @@
 # WhisperType
 
-Lokale Sprache-zu-Text Diktierfunktion für macOS – komplett offline, powered by whisper.cpp.
+Local speech-to-text dictation for macOS — fully offline, powered by whisper.cpp.
+
+> **Deutsche Version:** Siehe [README.de.md](README.de.md)
 
 ## Features
 
-- **100% Lokal** – Keine Daten verlassen deinen Mac. Kein Internet nötig nach dem Modell-Download.
-- **Deutsch & Englisch** – Automatische Spracherkennung, Mischsprachen-Support (z.B. deutsche Sätze mit englischen Fachbegriffen)
-- **Globaler Hotkey** – Funktioniert in jeder App. Einstellbare Tastenkombination.
-- **Füllwort-Filter** – Entfernt automatisch "ähm", "also", "uhm" etc.
-- **Native macOS App** – Menübar-App, kein Dock-Icon, minimaler Ressourcenverbrauch
+- **100% Local** — No data leaves your Mac. No internet needed after model download.
+- **German & English** — Automatic language detection, mixed-language support (e.g. German sentences with English technical terms)
+- **Global Hotkey** — Works in any app. Configurable keyboard shortcut.
+- **Filler Word Filter** — Automatically removes "um", "uh", "like", "you know", etc.
+- **Native macOS App** — Menubar app, no dock icon, minimal resource usage
 
-## Systemanforderungen
+## System Requirements
 
-- macOS 14 (Sonoma) oder neuer
-- Apple Silicon (M1/M2/M3) empfohlen – Intel wird unterstützt aber langsamer
-- Mindestens 8 GB RAM (16 GB empfohlen für large-v3-turbo Modell)
-- ~3 GB freier Speicher für das Whisper-Modell
+- macOS 14 (Sonoma) or later
+- Apple Silicon (M1/M2/M3) recommended — Intel is supported but slower
+- At least 8 GB RAM (16 GB recommended for large-v3-turbo model)
+- ~3 GB free disk space for the Whisper model
 
 ## Installation
 
-### DMG Download (empfohlen)
+### DMG Download (recommended)
 
-1. Lade die neueste Version von der [Releases-Seite](../../releases/latest) herunter
-2. Öffne die `.dmg` Datei
-3. Ziehe WhisperType in den Programme-Ordner
-4. Starte WhisperType — beim ersten Start wird das Whisper-Modell heruntergeladen (~1.5 GB)
+1. Download the latest version from the [Releases page](../../releases/latest)
+2. Open the `.dmg` file
+3. Drag WhisperType to your Applications folder
+4. Launch WhisperType — the Whisper model will be downloaded on first launch (~1.5 GB)
 
-### Homebrew (coming soon)
+### Homebrew
 
 ```bash
 brew tap marc1107/tap
 brew install --cask whisper-type
 ```
 
-### Aus Source bauen
+### Build from Source
 
-1. Xcode 15+ und Homebrew installieren
-2. Repository klonen:
+1. Install Xcode 15+ and Homebrew
+2. Clone the repository:
    ```bash
    git clone --recursive https://github.com/marc1107/whisper-type.git
    cd whisper-type
    ```
-3. Bauen:
+3. Build:
    ```bash
    brew install cmake xcodegen
    make build
    ```
-4. App starten:
+4. Run the app:
    ```bash
    open build/Release/WhisperType.app
    ```
 
-### Berechtigungen einrichten
+### Setting Up Permissions
 
-Nach dem ersten Start muss WhisperType in den Systemeinstellungen freigegeben werden:
-1. **Mikrofon:** Wird automatisch angefragt
-2. **Bedienungshilfen:** Systemeinstellungen → Datenschutz & Sicherheit → Bedienungshilfen → WhisperType aktivieren
+After first launch, WhisperType needs to be granted permissions in System Settings:
+1. **Microphone:** Automatically prompted
+2. **Accessibility:** System Settings > Privacy & Security > Accessibility > Enable WhisperType
 
-## Benutzung
+## Usage
 
-1. WhisperType startet als Mikrofon-Icon in der Menüleiste
-2. Klicke in ein beliebiges Textfeld (Browser, Editor, Chat, IDE...)
-3. Drücke den Hotkey (Standard: Fn+Control)
-4. Sprich deinen Text
-5. Lasse los (Push-to-Talk) oder drücke erneut (Toggle-Modus)
-6. Der transkribierte Text wird automatisch eingefügt
+1. WhisperType appears as a microphone icon in the menubar
+2. Click into any text field (browser, editor, chat, IDE...)
+3. Press the hotkey (default: Fn+Control)
+4. Speak your text
+5. Release (Push-to-Talk) or press again (Toggle mode)
+6. The transcribed text is automatically inserted
 
-## Einstellungen
+## Settings
 
-Über das Menübar-Icon → Einstellungen:
-- Hotkey ändern
-- Push-to-Talk oder Toggle-Modus
-- Whisper-Modell wechseln
-- Sprache festlegen oder automatisch erkennen lassen
-- Füllwort-Filter konfigurieren
+Via the menubar icon > Settings:
+- Change hotkey
+- Push-to-Talk or Toggle mode
+- Switch Whisper model
+- Set language or use automatic detection
+- Configure filler word filter
+- Change app language (English/German)
 
-## Unterstützte Whisper-Modelle
+## Supported Whisper Models
 
-| Modell | Größe | RAM-Bedarf | Geschwindigkeit | Qualität |
-|--------|-------|------------|-----------------|----------|
-| tiny | 75 MB | ~1 GB | Sehr schnell | Basis |
-| base | 142 MB | ~1 GB | Schnell | Gut |
-| small | 466 MB | ~2 GB | Mittel | Sehr gut |
-| medium | 1.5 GB | ~5 GB | Langsamer | Exzellent |
-| large-v3-turbo | 1.5 GB | ~5 GB | Mittel | Exzellent |
+| Model | Size | RAM Required | Speed | Quality |
+|-------|------|-------------|-------|---------|
+| tiny | 75 MB | ~1 GB | Very fast | Basic |
+| base | 142 MB | ~1 GB | Fast | Good |
+| small | 466 MB | ~2 GB | Medium | Very good |
+| medium | 1.5 GB | ~5 GB | Slower | Excellent |
+| large-v3-turbo | 1.5 GB | ~5 GB | Medium | Excellent |
 
-**Empfehlung für M1 16GB:** `large-v3-turbo` – beste Balance aus Qualität und Geschwindigkeit.
+**Recommendation for M1 16GB:** `large-v3-turbo` — best balance of quality and speed.
 
-## Lizenz
+## License
 
 MIT License

--- a/WhisperType/App/AppDelegate.swift
+++ b/WhisperType/App/AppDelegate.swift
@@ -3,17 +3,15 @@ import Cocoa
 
 final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
-        // Request accessibility permission
         if !AXIsProcessTrusted() {
             let options = [kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: true]
             AXIsProcessTrustedWithOptions(options as CFDictionary)
         }
 
-        // Request microphone permission explicitly
         AVCaptureDevice.requestAccess(for: .audio) { granted in
             if !granted {
                 DispatchQueue.main.async {
-                    NSLog("WhisperType: Mikrofon-Berechtigung wurde nicht erteilt.")
+                    NSLog(NSLocalizedString("mic.permission_denied", comment: ""))
                 }
             }
         }

--- a/WhisperType/App/AppState.swift
+++ b/WhisperType/App/AppState.swift
@@ -46,7 +46,6 @@ final class AppState: ObservableObject {
             setError(error.localizedDescription)
         }
 
-        // Observe status changes for overlay
         $status
             .receive(on: DispatchQueue.main)
             .sink { [weak self] newStatus in
@@ -107,7 +106,7 @@ final class AppState: ObservableObject {
         }() else { return }
 
         guard isModelLoaded else {
-            setError("Kein Whisper-Modell geladen. Bitte zuerst ein Modell herunterladen.")
+            setError(NSLocalizedString("error.no_model", comment: ""))
             return
         }
 

--- a/WhisperType/Audio/AudioRecorder.swift
+++ b/WhisperType/Audio/AudioRecorder.swift
@@ -85,7 +85,7 @@ enum AudioRecorderError: LocalizedError {
     var errorDescription: String? {
         switch self {
         case .converterCreationFailed:
-            return "Audio-Konverter konnte nicht erstellt werden."
+            return NSLocalizedString("error.converter_failed", comment: "")
         }
     }
 }

--- a/WhisperType/Info.plist
+++ b/WhisperType/Info.plist
@@ -5,7 +5,7 @@
     <key>LSUIElement</key>
     <true/>
     <key>NSMicrophoneUsageDescription</key>
-    <string>WhisperType benötigt Zugriff auf das Mikrofon für die Spracheingabe.</string>
+    <string>WhisperType needs microphone access for speech input.</string>
     <key>CFBundleName</key>
     <string>WhisperType</string>
     <key>CFBundleIdentifier</key>
@@ -18,5 +18,12 @@
     <string>APPL</string>
     <key>CFBundleExecutable</key>
     <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleLocalizations</key>
+    <array>
+        <string>en</string>
+        <string>de</string>
+    </array>
 </dict>
 </plist>

--- a/WhisperType/Input/HotkeyManager.swift
+++ b/WhisperType/Input/HotkeyManager.swift
@@ -144,7 +144,7 @@ enum HotkeyError: LocalizedError {
     var errorDescription: String? {
         switch self {
         case .tapCreationFailed:
-            return "Globaler Hotkey konnte nicht registriert werden. Bitte Bedienungshilfen-Berechtigung prüfen."
+            return NSLocalizedString("error.hotkey_failed", comment: "")
         }
     }
 }

--- a/WhisperType/Models/AppSettings.swift
+++ b/WhisperType/Models/AppSettings.swift
@@ -1,6 +1,20 @@
 import Foundation
 import SwiftUI
 
+enum AppLanguage: String, CaseIterable {
+    case system = "system"
+    case english = "en"
+    case german = "de"
+
+    var displayName: String {
+        switch self {
+        case .system: return NSLocalizedString("settings.general.language_system", comment: "")
+        case .english: return "English"
+        case .german: return "Deutsch"
+        }
+    }
+}
+
 enum HotkeyMode: String, CaseIterable {
     case pushToTalk = "pushToTalk"
     case toggle = "toggle"
@@ -56,6 +70,7 @@ final class AppSettings: ObservableObject {
     @AppStorage("insertionMethod") var insertionMethod: TextInsertionMethod = .clipboard
     @AppStorage("maxRecordingDuration") var maxRecordingDuration: Double = 120
     @AppStorage("launchAtLogin") var launchAtLogin: Bool = false
+    @AppStorage("appLanguage") var appLanguage: AppLanguage = .system
     @AppStorage("customFillerWords") var customFillerWordsRaw: String = ""
 
     var customFillerWords: [String] {
@@ -94,7 +109,7 @@ final class AppSettings: ObservableObject {
         if hotkeyKeyCode >= 0 {
             parts.append(Self.keyCodeToString(UInt16(hotkeyKeyCode)))
         }
-        return parts.isEmpty ? "Nicht gesetzt" : parts.joined(separator: " + ")
+        return parts.isEmpty ? NSLocalizedString("settings.hotkey.not_set", comment: "") : parts.joined(separator: " + ")
     }
 
     static func keyCodeToString(_ keyCode: UInt16) -> String {

--- a/WhisperType/Resources/de.lproj/InfoPlist.strings
+++ b/WhisperType/Resources/de.lproj/InfoPlist.strings
@@ -1,0 +1,1 @@
+NSMicrophoneUsageDescription = "WhisperType benötigt Zugriff auf das Mikrofon für die Spracheingabe.";

--- a/WhisperType/Resources/de.lproj/Localizable.strings
+++ b/WhisperType/Resources/de.lproj/Localizable.strings
@@ -1,0 +1,80 @@
+/* Menu Bar */
+"status.ready" = "Bereit";
+"status.no_model" = "Kein Modell geladen";
+"status.recording" = "Aufnahme...";
+"status.transcribing" = "Transkribiere...";
+"status.injecting" = "Füge ein...";
+"status.downloading_model" = "Lade Modell...";
+"status.done" = "Fertig";
+
+"menu.download_model" = "Modell herunterladen (%@)";
+"menu.downloading_model" = "Lade %@...";
+"menu.settings" = "Einstellungen...";
+"menu.quit" = "Beenden";
+
+/* Settings - General */
+"settings.general" = "Allgemein";
+"settings.general.launch_at_login" = "Bei Login starten";
+"settings.general.show_overlay" = "Status-Overlay anzeigen";
+"settings.general.insertion_method" = "Einfügemethode";
+"settings.general.insertion_clipboard" = "Zwischenablage (Cmd+V)";
+"settings.general.insertion_typing" = "Tastatur-Simulation";
+"settings.general.app_language" = "App-Sprache";
+"settings.general.language_system" = "Systemstandard";
+"settings.general.language_restart_hint" = "Starte die App neu, damit die Sprachänderung wirksam wird.";
+
+/* Settings - Permissions */
+"settings.permissions" = "Berechtigungen";
+"settings.permissions.accessibility" = "Bedienungshilfen: %@";
+"settings.permissions.microphone" = "Mikrofon: %@";
+"settings.permissions.granted" = "Erteilt";
+"settings.permissions.missing" = "Fehlt";
+"settings.permissions.open" = "Öffnen";
+
+/* Settings - Hotkey */
+"settings.hotkey" = "Hotkey";
+"settings.hotkey.shortcut" = "Tastenkombination";
+"settings.hotkey.press_combination" = "Drücke Tastenkombination...";
+"settings.hotkey.press_hint" = "Drücke die gewünschte Tastenkombination. Nur Modifier-Tasten (Fn, Control, Option, Shift, Command) oder Modifier + Taste.";
+"settings.hotkey.change" = "Ändern";
+"settings.hotkey.cancel" = "Abbrechen";
+"settings.hotkey.mode" = "Modus";
+"settings.hotkey.recording_mode" = "Aufnahmemodus";
+"settings.hotkey.push_to_talk" = "Push-to-Talk (gedrückt halten)";
+"settings.hotkey.toggle" = "Toggle (einmal drücken)";
+"settings.hotkey.recording" = "Aufnahme";
+"settings.hotkey.max_duration" = "Maximale Dauer:";
+"settings.hotkey.seconds" = "Sekunden";
+"settings.hotkey.not_set" = "Nicht gesetzt";
+
+/* Settings - Transcription */
+"settings.transcription" = "Transcription";
+"settings.transcription.model" = "Modell";
+"settings.transcription.whisper_model" = "Whisper-Modell";
+"settings.transcription.download_model" = "Modell herunterladen";
+"settings.transcription.downloading" = "Wird heruntergeladen...";
+"settings.transcription.cancel" = "Abbrechen";
+"settings.transcription.loaded" = "Geladen";
+"settings.transcription.load_model" = "Modell laden";
+"settings.transcription.delete" = "Löschen";
+"settings.transcription.language" = "Sprache";
+"settings.transcription.language_auto" = "Automatisch";
+"settings.transcription.language_german" = "Deutsch";
+"settings.transcription.language_english" = "Englisch";
+"settings.transcription.postprocessing" = "Nachbearbeitung";
+"settings.transcription.remove_fillers" = "Füllwörter entfernen";
+"settings.transcription.custom_fillers" = "Eigene Füllwörter:";
+"settings.transcription.new_filler" = "Neues Füllwort";
+"settings.transcription.add" = "Hinzufügen";
+
+/* Errors */
+"error.no_model" = "Kein Whisper-Modell geladen. Bitte zuerst ein Modell herunterladen.";
+"error.model_load_failed" = "Whisper-Modell konnte nicht geladen werden.";
+"error.model_not_loaded" = "Kein Whisper-Modell geladen.";
+"error.transcription_failed" = "Transkription fehlgeschlagen.";
+"error.converter_failed" = "Audio-Konverter konnte nicht erstellt werden.";
+"error.hotkey_failed" = "Globaler Hotkey konnte nicht registriert werden. Bitte Bedienungshilfen-Berechtigung prüfen.";
+"error.download_failed" = "Modell-Download fehlgeschlagen.";
+
+/* Microphone */
+"mic.permission_denied" = "WhisperType: Mikrofon-Berechtigung wurde nicht erteilt.";

--- a/WhisperType/Resources/en.lproj/InfoPlist.strings
+++ b/WhisperType/Resources/en.lproj/InfoPlist.strings
@@ -1,0 +1,1 @@
+NSMicrophoneUsageDescription = "WhisperType needs microphone access for speech input.";

--- a/WhisperType/Resources/en.lproj/Localizable.strings
+++ b/WhisperType/Resources/en.lproj/Localizable.strings
@@ -1,0 +1,80 @@
+/* Menu Bar */
+"status.ready" = "Ready";
+"status.no_model" = "No model loaded";
+"status.recording" = "Recording...";
+"status.transcribing" = "Transcribing...";
+"status.injecting" = "Inserting...";
+"status.downloading_model" = "Downloading model...";
+"status.done" = "Done";
+
+"menu.download_model" = "Download model (%@)";
+"menu.downloading_model" = "Downloading %@...";
+"menu.settings" = "Settings...";
+"menu.quit" = "Quit";
+
+/* Settings - General */
+"settings.general" = "General";
+"settings.general.launch_at_login" = "Launch at login";
+"settings.general.show_overlay" = "Show status overlay";
+"settings.general.insertion_method" = "Insertion method";
+"settings.general.insertion_clipboard" = "Clipboard (Cmd+V)";
+"settings.general.insertion_typing" = "Keyboard simulation";
+"settings.general.app_language" = "App language";
+"settings.general.language_system" = "System default";
+"settings.general.language_restart_hint" = "Restart the app for the language change to take effect.";
+
+/* Settings - Permissions */
+"settings.permissions" = "Permissions";
+"settings.permissions.accessibility" = "Accessibility: %@";
+"settings.permissions.microphone" = "Microphone: %@";
+"settings.permissions.granted" = "Granted";
+"settings.permissions.missing" = "Missing";
+"settings.permissions.open" = "Open";
+
+/* Settings - Hotkey */
+"settings.hotkey" = "Hotkey";
+"settings.hotkey.shortcut" = "Keyboard shortcut";
+"settings.hotkey.press_combination" = "Press key combination...";
+"settings.hotkey.press_hint" = "Press the desired key combination. Modifier keys only (Fn, Control, Option, Shift, Command) or modifier + key.";
+"settings.hotkey.change" = "Change";
+"settings.hotkey.cancel" = "Cancel";
+"settings.hotkey.mode" = "Mode";
+"settings.hotkey.recording_mode" = "Recording mode";
+"settings.hotkey.push_to_talk" = "Push-to-Talk (hold)";
+"settings.hotkey.toggle" = "Toggle (press once)";
+"settings.hotkey.recording" = "Recording";
+"settings.hotkey.max_duration" = "Maximum duration:";
+"settings.hotkey.seconds" = "seconds";
+"settings.hotkey.not_set" = "Not set";
+
+/* Settings - Transcription */
+"settings.transcription" = "Transcription";
+"settings.transcription.model" = "Model";
+"settings.transcription.whisper_model" = "Whisper model";
+"settings.transcription.download_model" = "Download model";
+"settings.transcription.downloading" = "Downloading...";
+"settings.transcription.cancel" = "Cancel";
+"settings.transcription.loaded" = "Loaded";
+"settings.transcription.load_model" = "Load model";
+"settings.transcription.delete" = "Delete";
+"settings.transcription.language" = "Language";
+"settings.transcription.language_auto" = "Automatic";
+"settings.transcription.language_german" = "German";
+"settings.transcription.language_english" = "English";
+"settings.transcription.postprocessing" = "Post-processing";
+"settings.transcription.remove_fillers" = "Remove filler words";
+"settings.transcription.custom_fillers" = "Custom filler words:";
+"settings.transcription.new_filler" = "New filler word";
+"settings.transcription.add" = "Add";
+
+/* Errors */
+"error.no_model" = "No Whisper model loaded. Please download a model first.";
+"error.model_load_failed" = "Failed to load Whisper model.";
+"error.model_not_loaded" = "No Whisper model loaded.";
+"error.transcription_failed" = "Transcription failed.";
+"error.converter_failed" = "Failed to create audio converter.";
+"error.hotkey_failed" = "Failed to register global hotkey. Please check Accessibility permissions.";
+"error.download_failed" = "Model download failed.";
+
+/* Microphone */
+"mic.permission_denied" = "WhisperType: Microphone permission was not granted.";

--- a/WhisperType/Transcription/ModelManager.swift
+++ b/WhisperType/Transcription/ModelManager.swift
@@ -79,7 +79,7 @@ enum ModelManagerError: LocalizedError {
 
     var errorDescription: String? {
         switch self {
-        case .downloadFailed: return "Modell-Download fehlgeschlagen."
+        case .downloadFailed: return NSLocalizedString("error.download_failed", comment: "")
         }
     }
 }

--- a/WhisperType/Transcription/WhisperEngine.swift
+++ b/WhisperType/Transcription/WhisperEngine.swift
@@ -95,9 +95,9 @@ enum WhisperError: LocalizedError {
 
     var errorDescription: String? {
         switch self {
-        case .modelLoadFailed: return "Whisper-Modell konnte nicht geladen werden."
-        case .modelNotLoaded: return "Kein Whisper-Modell geladen."
-        case .transcriptionFailed: return "Transkription fehlgeschlagen."
+        case .modelLoadFailed: return NSLocalizedString("error.model_load_failed", comment: "")
+        case .modelNotLoaded: return NSLocalizedString("error.model_not_loaded", comment: "")
+        case .transcriptionFailed: return NSLocalizedString("error.transcription_failed", comment: "")
         }
     }
 }

--- a/WhisperType/UI/HotkeyRecorderView.swift
+++ b/WhisperType/UI/HotkeyRecorderView.swift
@@ -12,7 +12,7 @@ struct HotkeyRecorderView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack {
-                Text(isRecording ? (displayText.isEmpty ? "Drücke Tastenkombination..." : displayText) : settings.hotkeyDisplayString)
+                Text(isRecording ? (displayText.isEmpty ? NSLocalizedString("settings.hotkey.press_combination", comment: "") : displayText) : settings.hotkeyDisplayString)
                     .font(.system(size: 14, weight: .medium, design: .rounded))
                     .foregroundColor(isRecording ? .accentColor : .primary)
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -28,12 +28,12 @@ struct HotkeyRecorderView: View {
                     )
 
                 if isRecording {
-                    Button("Abbrechen") {
+                    Button(NSLocalizedString("settings.hotkey.cancel", comment: "")) {
                         stopRecording(save: false)
                     }
                     .buttonStyle(.bordered)
                 } else {
-                    Button("Ändern") {
+                    Button(NSLocalizedString("settings.hotkey.change", comment: "")) {
                         startRecording()
                     }
                     .buttonStyle(.bordered)
@@ -41,7 +41,7 @@ struct HotkeyRecorderView: View {
             }
 
             if isRecording {
-                Text("Drücke die gewünschte Tastenkombination. Nur Modifier-Tasten (Fn, Control, Option, Shift, Command) oder Modifier + Taste.")
+                Text(NSLocalizedString("settings.hotkey.press_hint", comment: ""))
                     .font(.caption)
                     .foregroundColor(.secondary)
             }
@@ -75,7 +75,6 @@ struct HotkeyRecorderView: View {
     }
 }
 
-// NSView-based key event monitor that captures key combos when recording
 struct HotkeyRecorderNSView: NSViewRepresentable {
     @Binding var isRecording: Bool
     @Binding var displayText: String
@@ -90,8 +89,8 @@ struct HotkeyRecorderNSView: NSViewRepresentable {
     }
 
     func updateNSView(_ nsView: NSView, context: Context) {
-        context.coordinator.parent = self
         let wasRecording = context.coordinator.isRecording
+        context.coordinator.parent = self
         context.coordinator.isRecording = isRecording
         if wasRecording != isRecording {
             context.coordinator.update()
@@ -108,8 +107,6 @@ struct HotkeyRecorderNSView: NSViewRepresentable {
         var localMonitor: Any?
         var flagsMonitor: Any?
         private var confirmTimer: Timer?
-        // Track the peak (most modifiers held at once) so releasing one key
-        // slightly before another doesn't lose the combination.
         private var peakModifiers: Int = 0
         private var peakKeyCode: Int = -1
 
@@ -122,7 +119,6 @@ struct HotkeyRecorderNSView: NSViewRepresentable {
             peakModifiers = 0
             peakKeyCode = -1
 
-            // Monitor key events
             localMonitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown]) { [weak self] event in
                 guard let self, self.isRecording else { return event }
 
@@ -138,10 +134,9 @@ struct HotkeyRecorderNSView: NSViewRepresentable {
                     self.parent.displayText = self.buildDisplayString(modifiers: modRaw, keyCode: Int(keyCode))
                     self.scheduleConfirm()
                 }
-                return nil // swallow the event
+                return nil
             }
 
-            // Monitor modifier changes (for modifier-only hotkeys)
             flagsMonitor = NSEvent.addLocalMonitorForEvents(matching: [.flagsChanged]) { [weak self] event in
                 guard let self, self.isRecording else { return event }
 
@@ -152,8 +147,6 @@ struct HotkeyRecorderNSView: NSViewRepresentable {
                 let peakBitCount = self.popcount(self.peakModifiers)
 
                 if modRaw != 0 {
-                    // Only update if we have MORE modifiers than before (building up the combo)
-                    // or if this is a fresh start
                     if currentBitCount >= peakBitCount || self.peakModifiers == 0 {
                         self.peakModifiers = modRaw
                         self.peakKeyCode = -1
@@ -161,11 +154,8 @@ struct HotkeyRecorderNSView: NSViewRepresentable {
                         self.parent.pendingModifiers = modRaw
                         self.parent.displayText = self.buildDisplayString(modifiers: modRaw, keyCode: -1)
                     }
-                    // Reset the confirm timer — user is still pressing keys
                     self.confirmTimer?.invalidate()
                 } else {
-                    // All modifiers released — confirm the peak combination after a short delay
-                    // so the user doesn't have to release all keys at the exact same time
                     if self.peakModifiers != 0 {
                         self.parent.pendingModifiers = self.peakModifiers
                         self.parent.pendingKeyCode = self.peakKeyCode
@@ -231,13 +221,11 @@ struct HotkeyRecorderNSView: NSViewRepresentable {
         }
     }
 
-    // Minimal NSView subclass to hook into view lifecycle
     class RecorderView: NSView {
         weak var delegate: Coordinator?
 
         override func viewDidMoveToWindow() {
             super.viewDidMoveToWindow()
-            // Start/stop monitoring based on recording state — driven by updateNSView
         }
 
         override func removeFromSuperview() {
@@ -247,7 +235,6 @@ struct HotkeyRecorderNSView: NSViewRepresentable {
     }
 }
 
-// Extension to start/stop monitoring when isRecording changes
 extension HotkeyRecorderNSView.Coordinator {
     func update() {
         if isRecording {

--- a/WhisperType/UI/MenuBarView.swift
+++ b/WhisperType/UI/MenuBarView.swift
@@ -17,7 +17,7 @@ struct MenuBarView: View {
             if appState.modelManager.isDownloading {
                 Divider()
                 VStack(alignment: .leading, spacing: 4) {
-                    Text("Lade \(appState.settings.selectedModel.displayName)...")
+                    Text(String(format: NSLocalizedString("menu.downloading_model", comment: ""), appState.settings.selectedModel.displayName))
                         .font(.caption)
                     ProgressView(value: appState.modelManager.downloadProgress)
                         .progressViewStyle(.linear)
@@ -27,14 +27,12 @@ struct MenuBarView: View {
                 }
             } else if !appState.isModelLoaded {
                 Divider()
-                Button("Modell herunterladen (\(appState.settings.selectedModel.displayName))") {
+                Button(String(format: NSLocalizedString("menu.download_model", comment: ""), appState.settings.selectedModel.displayName)) {
                     Task {
                         do {
                             try await appState.modelManager.downloadModel(appState.settings.selectedModel)
                             await appState.loadSelectedModel()
-                        } catch {
-                            // Error shown via status
-                        }
+                        } catch {}
                     }
                 }
             }
@@ -50,10 +48,10 @@ struct MenuBarView: View {
             Divider()
 
             SettingsLink {
-                Text("Einstellungen...")
+                Text(NSLocalizedString("menu.settings", comment: ""))
             }
 
-            Button("Beenden") {
+            Button(NSLocalizedString("menu.quit", comment: "")) {
                 NSApplication.shared.terminate(nil)
             }
             .keyboardShortcut("q")
@@ -70,12 +68,14 @@ struct MenuBarView: View {
         switch appState.status {
         case .idle:
             if appState.modelManager.isDownloading {
-                return "Lade Modell..."
+                return NSLocalizedString("status.downloading_model", comment: "")
             }
-            return appState.isModelLoaded ? "Bereit" : "Kein Modell geladen"
-        case .recording: return "Aufnahme..."
-        case .transcribing: return "Transkribiere..."
-        case .injecting: return "Füge ein..."
+            return appState.isModelLoaded
+                ? NSLocalizedString("status.ready", comment: "")
+                : NSLocalizedString("status.no_model", comment: "")
+        case .recording: return NSLocalizedString("status.recording", comment: "")
+        case .transcribing: return NSLocalizedString("status.transcribing", comment: "")
+        case .injecting: return NSLocalizedString("status.injecting", comment: "")
         case .error(let msg): return msg
         }
     }

--- a/WhisperType/UI/SettingsView.swift
+++ b/WhisperType/UI/SettingsView.swift
@@ -8,13 +8,13 @@ struct SettingsView: View {
     var body: some View {
         TabView {
             GeneralSettingsTab(settings: appState.settings)
-                .tabItem { Label("Allgemein", systemImage: "gear") }
+                .tabItem { Label(NSLocalizedString("settings.general", comment: ""), systemImage: "gear") }
 
             HotkeySettingsTab(settings: appState.settings)
-                .tabItem { Label("Hotkey", systemImage: "keyboard") }
+                .tabItem { Label(NSLocalizedString("settings.hotkey", comment: ""), systemImage: "keyboard") }
 
             TranscriptionSettingsTab(appState: appState)
-                .tabItem { Label("Transkription", systemImage: "text.bubble") }
+                .tabItem { Label(NSLocalizedString("settings.transcription", comment: ""), systemImage: "text.bubble") }
         }
         .frame(width: 500, height: 420)
     }
@@ -31,8 +31,8 @@ struct GeneralSettingsTab: View {
 
     var body: some View {
         Form {
-            Section("Allgemein") {
-                Toggle("Bei Login starten", isOn: $settings.launchAtLogin)
+            Section(NSLocalizedString("settings.general", comment: "")) {
+                Toggle(NSLocalizedString("settings.general.launch_at_login", comment: ""), isOn: $settings.launchAtLogin)
                     .onChange(of: settings.launchAtLogin) { _, newValue in
                         do {
                             if newValue {
@@ -45,22 +45,44 @@ struct GeneralSettingsTab: View {
                         }
                     }
 
-                Toggle("Status-Overlay anzeigen", isOn: $settings.showOverlay)
+                Toggle(NSLocalizedString("settings.general.show_overlay", comment: ""), isOn: $settings.showOverlay)
 
-                Picker("Einfügemethode", selection: $settings.insertionMethod) {
-                    Text("Zwischenablage (Cmd+V)").tag(TextInsertionMethod.clipboard)
-                    Text("Tastatur-Simulation").tag(TextInsertionMethod.typing)
+                Picker(NSLocalizedString("settings.general.insertion_method", comment: ""), selection: $settings.insertionMethod) {
+                    Text(NSLocalizedString("settings.general.insertion_clipboard", comment: "")).tag(TextInsertionMethod.clipboard)
+                    Text(NSLocalizedString("settings.general.insertion_typing", comment: "")).tag(TextInsertionMethod.typing)
+                }
+
+                Picker(NSLocalizedString("settings.general.app_language", comment: ""), selection: $settings.appLanguage) {
+                    ForEach(AppLanguage.allCases, id: \.self) { lang in
+                        Text(lang.displayName).tag(lang)
+                    }
+                }
+                .onChange(of: settings.appLanguage) { _, newValue in
+                    if newValue == .system {
+                        UserDefaults.standard.removeObject(forKey: "AppleLanguages")
+                    } else {
+                        UserDefaults.standard.set([newValue.rawValue], forKey: "AppleLanguages")
+                    }
+                }
+
+                if settings.appLanguage != .system {
+                    Text(NSLocalizedString("settings.general.language_restart_hint", comment: ""))
+                        .font(.caption)
+                        .foregroundColor(.secondary)
                 }
             }
 
-            Section("Berechtigungen") {
+            Section(NSLocalizedString("settings.permissions", comment: "")) {
                 HStack {
                     Image(systemName: accessibilityGranted ? "checkmark.circle.fill" : "xmark.circle.fill")
                         .foregroundColor(accessibilityGranted ? .green : .red)
-                    Text("Bedienungshilfen: \(accessibilityGranted ? "Erteilt" : "Fehlt")")
+                    Text(String(format: NSLocalizedString("settings.permissions.accessibility", comment: ""),
+                                accessibilityGranted
+                                    ? NSLocalizedString("settings.permissions.granted", comment: "")
+                                    : NSLocalizedString("settings.permissions.missing", comment: "")))
                     Spacer()
                     if !accessibilityGranted {
-                        Button("Öffnen") {
+                        Button(NSLocalizedString("settings.permissions.open", comment: "")) {
                             if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility") {
                                 NSWorkspace.shared.open(url)
                             }
@@ -71,10 +93,13 @@ struct GeneralSettingsTab: View {
                 HStack {
                     Image(systemName: microphoneGranted ? "checkmark.circle.fill" : "xmark.circle.fill")
                         .foregroundColor(microphoneGranted ? .green : .red)
-                    Text("Mikrofon: \(microphoneGranted ? "Erteilt" : "Fehlt")")
+                    Text(String(format: NSLocalizedString("settings.permissions.microphone", comment: ""),
+                                microphoneGranted
+                                    ? NSLocalizedString("settings.permissions.granted", comment: "")
+                                    : NSLocalizedString("settings.permissions.missing", comment: "")))
                     Spacer()
                     if !microphoneGranted {
-                        Button("Öffnen") {
+                        Button(NSLocalizedString("settings.permissions.open", comment: "")) {
                             if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone") {
                                 NSWorkspace.shared.open(url)
                             }
@@ -107,24 +132,24 @@ struct HotkeySettingsTab: View {
 
     var body: some View {
         Form {
-            Section("Tastenkombination") {
+            Section(NSLocalizedString("settings.hotkey.shortcut", comment: "")) {
                 HotkeyRecorderView(settings: settings)
             }
 
-            Section("Modus") {
-                Picker("Aufnahmemodus", selection: $settings.hotkeyMode) {
-                    Text("Push-to-Talk (gedrückt halten)").tag(HotkeyMode.pushToTalk)
-                    Text("Toggle (einmal drücken)").tag(HotkeyMode.toggle)
+            Section(NSLocalizedString("settings.hotkey.mode", comment: "")) {
+                Picker(NSLocalizedString("settings.hotkey.recording_mode", comment: ""), selection: $settings.hotkeyMode) {
+                    Text(NSLocalizedString("settings.hotkey.push_to_talk", comment: "")).tag(HotkeyMode.pushToTalk)
+                    Text(NSLocalizedString("settings.hotkey.toggle", comment: "")).tag(HotkeyMode.toggle)
                 }
                 .pickerStyle(.radioGroup)
             }
 
-            Section("Aufnahme") {
+            Section(NSLocalizedString("settings.hotkey.recording", comment: "")) {
                 HStack {
-                    Text("Maximale Dauer:")
-                    TextField("Sekunden", value: $settings.maxRecordingDuration, format: .number)
+                    Text(NSLocalizedString("settings.hotkey.max_duration", comment: ""))
+                    TextField(NSLocalizedString("settings.hotkey.seconds", comment: ""), value: $settings.maxRecordingDuration, format: .number)
                         .frame(width: 80)
-                    Text("Sekunden")
+                    Text(NSLocalizedString("settings.hotkey.seconds", comment: ""))
                 }
             }
         }
@@ -143,8 +168,8 @@ struct TranscriptionSettingsTab: View {
 
     var body: some View {
         Form {
-            Section("Modell") {
-                Picker("Whisper-Modell", selection: Binding(
+            Section(NSLocalizedString("settings.transcription.model", comment: "")) {
+                Picker(NSLocalizedString("settings.transcription.whisper_model", comment: ""), selection: Binding(
                     get: { settings.selectedModel },
                     set: { settings.selectedModel = $0 }
                 )) {
@@ -171,14 +196,14 @@ struct TranscriptionSettingsTab: View {
                                 .monospacedDigit()
                                 .frame(width: 40, alignment: .trailing)
                         }
-                        Button("Abbrechen") {
+                        Button(NSLocalizedString("settings.transcription.cancel", comment: "")) {
                             appState.modelManager.cancelDownload()
                         }
                         .buttonStyle(.bordered)
                         .controlSize(.small)
                     }
                 } else if !settings.isModelDownloaded(settings.selectedModel) {
-                    Button("Modell herunterladen") {
+                    Button(NSLocalizedString("settings.transcription.download_model", comment: "")) {
                         Task {
                             try? await appState.modelManager.downloadModel(settings.selectedModel)
                             await appState.loadSelectedModel()
@@ -186,17 +211,17 @@ struct TranscriptionSettingsTab: View {
                     }
                 } else {
                     HStack {
-                        if appState.isModelLoaded && settings.selectedModel == settings.selectedModel {
-                            Label("Geladen", systemImage: "checkmark.circle.fill")
+                        if appState.isModelLoaded {
+                            Label(NSLocalizedString("settings.transcription.loaded", comment: ""), systemImage: "checkmark.circle.fill")
                                 .foregroundColor(.green)
                                 .font(.caption)
                         } else {
-                            Button("Modell laden") {
+                            Button(NSLocalizedString("settings.transcription.load_model", comment: "")) {
                                 Task { await appState.loadSelectedModel() }
                             }
                         }
                         Spacer()
-                        Button("Löschen", role: .destructive) {
+                        Button(NSLocalizedString("settings.transcription.delete", comment: ""), role: .destructive) {
                             try? appState.modelManager.deleteModel(settings.selectedModel)
                             appState.isModelLoaded = false
                         }
@@ -206,31 +231,31 @@ struct TranscriptionSettingsTab: View {
                 }
             }
 
-            Section("Sprache") {
-                Picker("Sprache", selection: Binding(
+            Section(NSLocalizedString("settings.transcription.language", comment: "")) {
+                Picker(NSLocalizedString("settings.transcription.language", comment: ""), selection: Binding(
                     get: { settings.language },
                     set: { settings.language = $0 }
                 )) {
-                    Text("Automatisch").tag(InputLanguage.auto)
-                    Text("Deutsch").tag(InputLanguage.german)
-                    Text("English").tag(InputLanguage.english)
+                    Text(NSLocalizedString("settings.transcription.language_auto", comment: "")).tag(InputLanguage.auto)
+                    Text(NSLocalizedString("settings.transcription.language_german", comment: "")).tag(InputLanguage.german)
+                    Text(NSLocalizedString("settings.transcription.language_english", comment: "")).tag(InputLanguage.english)
                 }
             }
 
-            Section("Nachbearbeitung") {
-                Toggle("Füllwörter entfernen", isOn: Binding(
+            Section(NSLocalizedString("settings.transcription.postprocessing", comment: "")) {
+                Toggle(NSLocalizedString("settings.transcription.remove_fillers", comment: ""), isOn: Binding(
                     get: { settings.fillerFilterEnabled },
                     set: { settings.fillerFilterEnabled = $0 }
                 ))
 
                 if settings.fillerFilterEnabled {
                     VStack(alignment: .leading, spacing: 8) {
-                        Text("Eigene Füllwörter:")
+                        Text(NSLocalizedString("settings.transcription.custom_fillers", comment: ""))
                             .font(.caption)
                         HStack {
-                            TextField("Neues Füllwort", text: $newFillerWord)
+                            TextField(NSLocalizedString("settings.transcription.new_filler", comment: ""), text: $newFillerWord)
                                 .textFieldStyle(.roundedBorder)
-                            Button("Hinzufügen") {
+                            Button(NSLocalizedString("settings.transcription.add", comment: "")) {
                                 guard !newFillerWord.trimmingCharacters(in: .whitespaces).isEmpty else { return }
                                 var words = settings.customFillerWords
                                 words.append(newFillerWord.lowercased().trimmingCharacters(in: .whitespaces))

--- a/WhisperType/UI/StatusOverlay.swift
+++ b/WhisperType/UI/StatusOverlay.swift
@@ -87,9 +87,9 @@ struct OverlayContentView: View {
 
     private var statusText: String {
         switch status {
-        case .recording: return "Aufnahme..."
-        case .transcribing: return "Transkribiere..."
-        case .injecting: return "Fertig"
+        case .recording: return NSLocalizedString("status.recording", comment: "")
+        case .transcribing: return NSLocalizedString("status.transcribing", comment: "")
+        case .injecting: return NSLocalizedString("status.done", comment: "")
         case .error(let msg): return String(msg.prefix(30))
         default: return ""
         }

--- a/project.yml
+++ b/project.yml
@@ -5,6 +5,10 @@ options:
     macOS: "14.0"
   xcodeVersion: "15.0"
   minimumXcodeGenVersion: "2.38"
+  developmentLanguage: en
+  knownRegions:
+    - en
+    - de
 
 settings:
   base:


### PR DESCRIPTION
## Summary
- Added full internationalization support with English and German localizations
- All hardcoded German strings replaced with `NSLocalizedString` across all Swift files
- Added app language selector in General settings (System default / English / German)
- README translated to English (primary), German version preserved as `README.de.md`
- New GitHub Actions workflow (`update-homebrew.yml`) auto-updates the Homebrew cask formula in `marc1107/homebrew-tap` when a release is published
- XcodeGen configured with `developmentLanguage: en` and `knownRegions: [en, de]`

## Files changed
- **Localization**: Added `en.lproj/` and `de.lproj/` with `Localizable.strings` and `InfoPlist.strings`
- **Swift files**: All UI and error strings now use `NSLocalizedString`
- **AppSettings**: New `AppLanguage` enum and `appLanguage` setting
- **SettingsView**: Language picker with restart hint
- **project.yml**: Development language and known regions
- **README.md**: English version (German moved to README.de.md)
- **.github/workflows/update-homebrew.yml**: Auto-update cask on release

## Test plan
- [x] Build succeeds
- [x] All 13 unit tests pass
- [x] `.lproj` files correctly bundled in app
- [ ] Verify app shows English UI on English system
- [ ] Verify app shows German UI on German system
- [ ] Verify language override works via settings

## Notes
The Homebrew auto-update workflow requires a `HOMEBREW_TAP_TOKEN` secret (a PAT with repo scope for `marc1107/homebrew-tap`) to be configured in the whisper-type repo settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)