### PR TITLE
fix: refresh model-download view in settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ WhisperType.xcodeproj/
 # Misc
 *.log
 *.tmp
+
+# Lsp Configuration
+buildServer.json

--- a/WhisperType/App/AppState.swift
+++ b/WhisperType/App/AppState.swift
@@ -19,10 +19,11 @@ final class AppState: ObservableObject {
     @Published var isModelLoaded: Bool = false
     @Published var isPreparingModel: Bool = false
 
+    var modelManager = ModelManager()
+
     let settings = AppSettings.shared
     let audioRecorder = AudioRecorder()
     let whisperEngine = WhisperEngine()
-    let modelManager = ModelManager()
     let hotkeyManager = HotkeyManager()
     let overlayController = OverlayWindowController()
     let llmProcessor = LLMProcessor()
@@ -33,6 +34,16 @@ final class AppState: ObservableObject {
     private var modelLoadTask: Task<Void, Never>?
 
     var isRecording: Bool { status == .recording }
+
+    init() {
+        self.modelManager = ModelManager()
+
+        modelManager.objectWillChange
+            .sink { [weak self] _ in
+                self?.objectWillChange.send()
+            }
+            .store(in: &cancellables)
+    }
 
     func setup() {
         hotkeyManager.onHotkeyDown = { [weak self] in


### PR DESCRIPTION
the AppState now introduces a init function, where the modelManager sends it's changes (for example the downloadProgress), and let's SwiftUI update it's few. Therefore the UI can update the progressBar, whenever the value was changed.